### PR TITLE
Fixed verified in captions / comments + stability changes

### DIFF
--- a/inscrawler/browser.py
+++ b/inscrawler/browser.py
@@ -2,6 +2,7 @@ import os
 
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -56,10 +57,13 @@ class Browser:
     def find(self, css_selector, elem=None, waittime=0):
         obj = elem or self.driver
 
-        if waittime:
-            WebDriverWait(obj, waittime).until(
-                EC.presence_of_element_located((By.CSS_SELECTOR, css_selector))
-            )
+        try:
+            if waittime:
+                WebDriverWait(obj, waittime).until(
+                    EC.presence_of_element_located((By.CSS_SELECTOR, css_selector))
+                )
+        except TimeoutException:
+            return None
 
         try:
             return obj.find_elements(By.CSS_SELECTOR, css_selector)

--- a/inscrawler/crawler.py
+++ b/inscrawler/crawler.py
@@ -218,7 +218,7 @@ class InsCrawler(Logging):
                 sys.stderr.write(
                     "\x1b[1;31m"
                     + "Failed to fetch the post: "
-                    + cur_key
+                    + cur_key or 'URL not fetched'
                     + "\x1b[0m"
                     + "\n"
                 )
@@ -228,7 +228,7 @@ class InsCrawler(Logging):
                 sys.stderr.write(
                     "\x1b[1;31m"
                     + "Failed to fetch the post: "
-                    + cur_key
+                    + cur_key if isinstance(cur_key,str) else 'URL not fetched'
                     + "\x1b[0m"
                     + "\n"
                 )

--- a/inscrawler/fetch.py
+++ b/inscrawler/fetch.py
@@ -149,7 +149,7 @@ def fetch_comments(browser, dict_post):
 
     ele_comments = browser.find(".eo2As .gElp9")
     comments = []
-    for els_comment in ele_comments[1:51]: # Download only top 50 comments
+    for els_comment in ele_comments[1:]:
         author = browser.find_one(".FPmhX", els_comment).text
         
         temp_element = browser.find("span", els_comment)

--- a/inscrawler/fetch.py
+++ b/inscrawler/fetch.py
@@ -44,8 +44,12 @@ def fetch_imgs(browser, dict_post):
     img_urls = set()
     while True:
         ele_imgs = browser.find("._97aPb img", waittime=10)
-        for ele_img in ele_imgs:
-            img_urls.add(ele_img.get_attribute("src"))
+        
+        if isinstance(ele_imgs, list):
+            for ele_img in ele_imgs:
+                img_urls.add(ele_img.get_attribute("src"))
+        else:
+            break
 
         next_photo_btn = browser.find_one("._6CZji .coreSpriteRightChevron")
 
@@ -111,8 +115,15 @@ def fetch_likers(browser, dict_post):
 
 def fetch_caption(browser, dict_post):
     ele_comments = browser.find(".eo2As .gElp9")
+
     if len(ele_comments) > 0:
-        dict_post["caption"] = browser.find_one("span", ele_comments[0]).text
+        
+        temp_element = browser.find("span",ele_comments[0])
+        
+        for element in temp_element:
+            
+            if element.text not in ['Verified',''] and 'caption' not in dict_post:
+                dict_post["caption"] = element.text
 
         fetch_mentions(dict_post["caption"], dict_post)
         fetch_hashtags(dict_post["caption"], dict_post)
@@ -138,9 +149,16 @@ def fetch_comments(browser, dict_post):
 
     ele_comments = browser.find(".eo2As .gElp9")
     comments = []
-    for els_comment in ele_comments[1:]:
+    for els_comment in ele_comments[1:51]: # Download only top 50 comments
         author = browser.find_one(".FPmhX", els_comment).text
-        comment = browser.find_one("span", els_comment).text
+        
+        temp_element = browser.find("span", els_comment)
+
+        for element in temp_element:
+            
+            if element.text not in ['Verified','']:
+                comment = element.text
+
         comment_obj = {"author": author, "comment": comment}
 
         fetch_mentions(comment, comment_obj)


### PR DESCRIPTION
**Fixed Verified** - fixes #48

Captions and comments from verified users were returning "Verified" instead of the caption or comment due to Instagram adding verified badge.

**Stability Changes**

Added try block in browser.py to avoid crawler crashing on videos where no img element is found.