### PR TITLE
introduce --fetch_details to hashtag search

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ optional arguments:
 
   --fetch_hashtags      fetch hashtags in the caption/comments (startwith #)
 
+  --fetch_details       fetch username and photo caption
+  # only available for "hashtag" search
+
 ```
 
 
@@ -52,6 +55,7 @@ python crawler.py posts_full -u cal_foodie -n 10 --fetch_likers --fetch_likes_pl
 python crawler.py posts_full -u cal_foodie -n 10 --fetch_comments
 python crawler.py profile -u cal_foodie -o ./output
 python crawler.py hashtag -t taiwan -o ./output
+python crawler.py hashtag -t taiwan -o ./output --fetch_details
 python crawler.py posts -u cal_foodie -n 100 -o ./output # deprecated
 ```
 1. Choose mode `posts`, you will get url, caption, first photo for each post; choose mode `posts_full`, you will get url, caption, all photos, time, comments, number of likes and views for each posts. Mode `posts_full` will take way longer than mode `posts`. **[`posts` is deprecated. For the recent posts, there is no quick way to get the post caption]**
@@ -65,7 +69,6 @@ The data format of `posts`:
 
 The data format of `posts_full`:
 <img width="1123" alt="Screen Shot 2019-03-17 at 11 02 24 PM" src="https://user-images.githubusercontent.com/3991678/54510055-1c4f4080-4909-11e9-8d06-8c35a08fb74e.png">
-
 
 ## Liker
 ![Liker Preivew](https://user-images.githubusercontent.com/3991678/41560884-4bbd42d2-72fd-11e8-8d56-84e7cf7187cd.gif)

--- a/inscrawler/browser.py
+++ b/inscrawler/browser.py
@@ -7,6 +7,7 @@ from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.keys import Keys
 
 from .utils import randmized_sleep
 
@@ -83,6 +84,15 @@ class Browser:
 
     def js_click(self, elem):
         self.driver.execute_script("arguments[0].click();", elem)
+
+    def open_new_tab(self, url):
+        self.driver.execute_script("window.open('%s');" %url)
+        self.driver.switch_to.window(self.driver.window_handles[1])
+
+    def close_current_tab(self):
+        self.driver.close()
+
+        self.driver.switch_to.window(self.driver.window_handles[0])
 
     def __del__(self):
         try:

--- a/inscrawler/crawler.py
+++ b/inscrawler/crawler.py
@@ -21,6 +21,7 @@ from .fetch import fetch_datetime
 from .fetch import fetch_imgs
 from .fetch import fetch_likers
 from .fetch import fetch_likes_plays
+from .fetch import fetch_details
 from .utils import instagram_int
 from .utils import randmized_sleep
 from .utils import retry
@@ -267,11 +268,19 @@ class InsCrawler(Logging):
             for ele in ele_posts:
                 key = ele.get_attribute("href")
                 if key not in key_set:
+                    dict_post = { "key": key }
                     ele_img = browser.find_one(".KL4Bh img", ele)
-                    caption = ele_img.get_attribute("alt")
-                    img_url = ele_img.get_attribute("src")
+                    dict_post["caption"] = ele_img.get_attribute("alt")
+                    dict_post["img_url"] = ele_img.get_attribute("src")
+
+                    fetch_details(browser, dict_post)
+
                     key_set.add(key)
-                    posts.append({"key": key, "caption": caption, "img_url": img_url})
+                    posts.append(dict_post)
+
+                    if len(posts) == num:
+                        break
+
             if pre_post_num == len(posts):
                 pbar.set_description("Wait for %s sec" % (wait_time))
                 sleep(wait_time)

--- a/inscrawler/fetch.py
+++ b/inscrawler/fetch.py
@@ -44,7 +44,7 @@ def fetch_imgs(browser, dict_post):
     img_urls = set()
     while True:
         ele_imgs = browser.find("._97aPb img", waittime=10)
-        
+
         if isinstance(ele_imgs, list):
             for ele_img in ele_imgs:
                 img_urls.add(ele_img.get_attribute("src"))
@@ -117,11 +117,11 @@ def fetch_caption(browser, dict_post):
     ele_comments = browser.find(".eo2As .gElp9")
 
     if len(ele_comments) > 0:
-        
+
         temp_element = browser.find("span",ele_comments[0])
-        
+
         for element in temp_element:
-            
+
             if element.text not in ['Verified',''] and 'caption' not in dict_post:
                 dict_post["caption"] = element.text
 
@@ -151,11 +151,11 @@ def fetch_comments(browser, dict_post):
     comments = []
     for els_comment in ele_comments[1:]:
         author = browser.find_one(".FPmhX", els_comment).text
-        
+
         temp_element = browser.find("span", els_comment)
 
         for element in temp_element:
-            
+
             if element.text not in ['Verified','']:
                 comment = element.text
 
@@ -168,3 +168,31 @@ def fetch_comments(browser, dict_post):
 
     if comments:
         dict_post["comments"] = comments
+
+
+def fetch_initial_comment(browser, dict_post):
+    comments_elem = browser.find_one("ul.XQXOT")
+    first_post_elem = browser.find_one(".ZyFrc", comments_elem)
+    caption = browser.find_one("span", first_post_elem)
+
+    if caption:
+        dict_post["description"] = caption.text
+
+
+def fetch_details(browser, dict_post):
+    if not settings.fetch_details:
+        return
+
+    browser.open_new_tab(dict_post["key"])
+
+    username = browser.find_one("a.FPmhX")
+    location = browser.find_one("a.O4GlU")
+
+    if username:
+        dict_post["username"] = username.text
+    if location:
+        dict_post["location"] = location.text
+
+    fetch_initial_comment(browser, dict_post)
+
+    browser.close_current_tab()

--- a/inscrawler/settings.py
+++ b/inscrawler/settings.py
@@ -4,6 +4,7 @@ defaults = {
     "fetch_comments": False,
     "fetch_mentions": False,
     "fetch_hashtags": False,
+    "fetch_details": False
 }
 
 


### PR DESCRIPTION
allows --fetch_details on "hashtag" search, which captures username, location and the image caption of a post.

Done by opening post in a new tab and scraping the data from there.