### PR TITLE
Fix posts_full crawling bug:

### DIFF
--- a/inscrawler/crawler.py
+++ b/inscrawler/crawler.py
@@ -197,13 +197,18 @@ class InsCrawler(Logging):
         pbar.set_description("fetching")
         cur_key = None
 
+        all_posts = self._get_posts(num)
+        i = 1
+
         # Fetching all posts
         for _ in range(num):
             dict_post = {}
 
             # Fetching post detail
             try:
-                check_next_post(cur_key)
+                if(i < num):
+                    check_next_post(all_posts[i]['key'])
+                    i = i + 1
 
                 # Fetching datetime and url as key
                 ele_a_datetime = browser.find_one(".eo2As .c-Yi7")
@@ -240,9 +245,6 @@ class InsCrawler(Logging):
             dict_posts[browser.current_url] = dict_post
 
             pbar.update(1)
-            left_arrow = browser.find_one(".HBoOv")
-            if left_arrow:
-                left_arrow.click()
 
         pbar.close()
         posts = list(dict_posts.values())


### PR DESCRIPTION
Problem: Instagram removed left_arrow from post page.
Solution: First fetch all posts, then get post info.
Fixes #72 