### PR TITLE
removed breaked author comment name

### DIFF
--- a/inscrawler/fetch.py
+++ b/inscrawler/fetch.py
@@ -148,16 +148,12 @@ def fetch_comments(browser, dict_post):
     ele_comments = browser.find(".eo2As .gElp9")
     comments = []
     for els_comment in ele_comments[1:]:
-        author = browser.find_one(".FPmhX", els_comment).text
-
         temp_element = browser.find("span", els_comment)
 
         for element in temp_element:
+		comment = element.text
 
-            if element.text not in ['Verified','']:
-                comment = element.text
-
-        comment_obj = {"author": author, "comment": comment}
+        comment_obj = {"comment": comment}
 
         fetch_mentions(comment, comment_obj)
         fetch_hashtags(comment, comment_obj)


### PR DESCRIPTION
Today this piece of code is broken:
author = browser.find_one(".FPmhX", els_comment).text
AttributeError: 'NoneType' object has no attribute 'text'
#75 

Maybe the class with the author name from a comment has changed and any comment is geted once the code break before taking the comment and saving.

This solution is not the best, once I remove the author name, the code stop breaking and therefore the code keeps taking comments and saving. Perhaps this could be a solution at the moment and in the future we can get back to the author's name 